### PR TITLE
Fix Java ffi build

### DIFF
--- a/java/ffi/src/main/cpp/jni_wrapper.cc
+++ b/java/ffi/src/main/cpp/jni_wrapper.cc
@@ -20,6 +20,7 @@
 #include <cassert>
 #include "abi.h"
 #include <stdint.h>
+#include <string>
 #include <inttypes.h>
 
 #include "org_apache_arrow_ffi_jni_JniWrapper.h"


### PR DESCRIPTION
Tried to build it (on Mac), but encountered the following error:

```
[ 20%] Building Java objects for arrow_ffi_java.jar                                            
[ 40%] Generating CMakeFiles/arrow_ffi_java.dir/java_class_filelist                            
[ 60%] Creating Java archive arrow_ffi_java.jar                                                                                                                                                
[ 60%] Built target arrow_ffi_java             
[ 80%] Building CXX object CMakeFiles/arrow_ffi_jni.dir/src/main/cpp/jni_wrapper.cc.o
/arrow/java/ffi/src/main/cpp/jni_wrapper.cc:58:29: error: implicit instantiation of undefined template 'std::__1::basic_string<char,                   
      std::__1::char_traits<char>, std::__1::allocator<char> >'                  
  void JniThrow(std::string message) { ThrowPendingException(message); }
                            ^          
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/iosfwd:209:32: note: template is declared here            
    class _LIBCPP_TEMPLATE_VIS basic_string;  
                               ^                                                               
/arrow/java/ffi/src/main/cpp/jni_wrapper.cc:64:62: error: implicit instantiation of undefined template 'std::__1::basic_string<char,                   
      std::__1::char_traits<char>, std::__1::allocator<char> >'                  
      std::string error_message = "Unable to find method " + std::string(name) +
                                                             ^                                 
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/iosfwd:209:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_string;
                               ^
...
```

Adding the include fixed the issue.
